### PR TITLE
Laravel 8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,11 @@
   },
   "require": {
     "php": ">=7.1",
-    "illuminate/container": "^5.6|^6|^7",
-    "illuminate/log": "^5.6|^6|^7",
-    "illuminate/queue": "^5.6|^6|^7",
-    "illuminate/routing": "^5.6|^6|^7",
-    "illuminate/support": "^5.6|^6|^7",
+    "illuminate/container": "^5.6|^6|^7|^8",
+    "illuminate/log": "^5.6|^6|^7|^8",
+    "illuminate/queue": "^5.6|^6|^7|^8",
+    "illuminate/routing": "^5.6|^6|^7|^8",
+    "illuminate/support": "^5.6|^6|^7|^8",
     "psr/log": "^1.0"
   },
   "autoload": {

--- a/src/RateHub/NewRelic/Providers/NewRelicServiceProvider.php
+++ b/src/RateHub/NewRelic/Providers/NewRelicServiceProvider.php
@@ -259,7 +259,7 @@ final class NewRelicServiceProvider extends ServiceProvider
             ],
             [
                 $event->connectionName,
-                get_class($event->job),
+                $event->job->resolveName(),
             ],
             $this->app['config']->get('newrelic.jobNameProvider')
         );


### PR DESCRIPTION
Howdy!

I am currently working on Laravel 8 based project and needed to integrate NewRelic. This library works well, with the exception of a few minor issues that I am addressing in this PR, which are:
- Relaxing dependency constraints to allow compatibility with Laravel 8 framework.
- Modifying how the job name is retrieved to use `Job::resolveName()` instead of `get_class($job)`, because in Laravel 8 the `$job` is always an instance of `Illuminate\Queue\Jobs\RedisJob` for Redis jobs or `Illuminate\Queue\Jobs\SqsJob` for SQS jobs and so forth, and this is what the `get_class()` will return. The `resolveName()` method instead will use the actual job names, such as `\App\Jobs\TestJob`.

*Note*: I have verified the `resolveName()` is available on Laravel 5.6 onward, so this should not cause any regressions.

Any feedback is appreciated!