### PR TITLE
Compatibility with Illuminate\Contracts\Debug\ExceptionHandler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
   },
   "require": {
     "php": ">=7.1",
+    "ext-json": "*",
     "illuminate/container": "^5.6|^6|^7|^8",
     "illuminate/log": "^5.6|^6|^7|^8",
     "illuminate/queue": "^5.6|^6|^7|^8",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "ext-newrelic": "This is what this package is built to use"
   },
   "require": {
-    "php": ">=7.1",
+    "php": ">=7.4",
     "ext-json": "*",
     "illuminate/container": "^5.6|^6|^7|^8",
     "illuminate/log": "^5.6|^6|^7|^8",

--- a/src/RateHub/NewRelic/Exceptions/ExceptionHandler.php
+++ b/src/RateHub/NewRelic/Exceptions/ExceptionHandler.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Arr;
 use RateHub\NewRelic\Contracts\Adapters\Adapter;
 use RateHub\NewRelic\Contracts\DetailProcessors\DetailProcessor;
 use RateHub\NewRelic\Contracts\Exceptions\ExceptionFilter;
+use Throwable;
 
 final class ExceptionHandler implements IExceptionHandler
 {
@@ -33,7 +34,7 @@ final class ExceptionHandler implements IExceptionHandler
         $this->exceptionFilter = $exceptionFilter;
     }
 
-    public function report(Exception $e)
+    public function report(Throwable $e)
     {
         if ($this->exceptionFilter->shouldReport($e)) {
             $this->logException($e);
@@ -43,20 +44,20 @@ final class ExceptionHandler implements IExceptionHandler
     /**
      * Determine if the exception should be reported.
      *
-     * @param  \Exception  $e
+     * @param  \Throwable  $e
      * @return bool
      */
-    public function shouldReport(Exception $e)
+    public function shouldReport(Throwable $e)
     {
         return $this->exceptionFilter->shouldReport($e);
     }
 
-    public function render($request, Exception $e)
+    public function render($request, Throwable $e)
     {
         // Nothing to do for New Relic
     }
 
-    public function renderForConsole($output, Exception $e)
+    public function renderForConsole($output, Throwable $e)
     {
         // Nothing to do for New Relic
     }
@@ -66,9 +67,9 @@ final class ExceptionHandler implements IExceptionHandler
      * Note: If you want some attributes ignored you have to add them
      * to the ini file under the field newrelic.attributes.exclude
      *
-     * @param Exception $exception
+     * @param \Throwable $exception
      */
-    protected function logException(Exception $exception)
+    protected function logException(Throwable $exception)
     {
         $logDetails = Arr::dot($this->detailProcessor->process([]));
         foreach ($logDetails as $param => $value) {

--- a/src/RateHub/NewRelic/Exceptions/ExceptionHandler.php
+++ b/src/RateHub/NewRelic/Exceptions/ExceptionHandler.php
@@ -2,7 +2,6 @@
 
 namespace RateHub\NewRelic\Exceptions;
 
-use Exception;
 use Illuminate\Contracts\Debug\ExceptionHandler as IExceptionHandler;
 use Illuminate\Support\Arr;
 use RateHub\NewRelic\Contracts\Adapters\Adapter;
@@ -67,7 +66,7 @@ final class ExceptionHandler implements IExceptionHandler
      * Note: If you want some attributes ignored you have to add them
      * to the ini file under the field newrelic.attributes.exclude
      *
-     * @param \Throwable $exception
+     * @param Throwable $exception
      */
     protected function logException(Throwable $exception)
     {


### PR DESCRIPTION
I installed v0.6 of this package into Laravel 8.10.0 and got this Error:

```bash
Declaration of RateHub\NewRelic\Exceptions\ExceptionHandler::report(Exception $e) must be compatible with Illuminate\Contracts\Debug\ExceptionHandler::report(Throwable $e)
```

1. I changed Exception to Throwable
2. required ext-json in composer.json as \RateHub\NewRelic\Exceptions\ExceptionHandler::logException#L77 uses `json_encode`