### PR TITLE
Laravel 9 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
   "require": {
     "php": ">=7.4",
     "ext-json": "*",
-    "illuminate/container": "^5.6|^6|^7|^8",
-    "illuminate/log": "^5.6|^6|^7|^8",
-    "illuminate/queue": "^5.6|^6|^7|^8",
-    "illuminate/routing": "^5.6|^6|^7|^8",
-    "illuminate/support": "^5.6|^6|^7|^8",
+    "illuminate/container": "^5.6|^6|^7|^8|^9",
+    "illuminate/log": "^5.6|^6|^7|^8|^9",
+    "illuminate/queue": "^5.6|^6|^7|^8|^9",
+    "illuminate/routing": "^5.6|^6|^7|^8|^9",
+    "illuminate/support": "^5.6|^6|^7|^8|^9",
     "psr/log": "^1.0"
   },
   "autoload": {
@@ -28,7 +28,7 @@
     }
   },
   "require-dev": {
-    "phpunit/phpunit": "~7.0",
+    "phpunit/phpunit": "^9.5",
     "squizlabs/php_codesniffer": "*"
   },
   "autoload-dev": {


### PR DESCRIPTION
👋 

I've been using this package within Laravel, but I was unable to upgrade to Laravel 9 due to some old dependencies

This PR adds support for Laravel 9 by updating illuminate packages and phpunit.